### PR TITLE
Improve portability by bundling deps locally. Fixes #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 install:
-	pip install -r requirements.txt
+	mkdir -p dist
+	pip install --target ./dist -r requirements.txt
 
 package: install
-	mkdir -p dist
 	cp main.py dist/
-	cp -r $(VIRTUAL_ENV)/lib/python2.7/site-packages/. dist/
-	cp -r $(VIRTUAL_ENV)/lib64/python2.7/site-packages/. dist/
 	cd dist; zip -r ../package.zip .
 
 clean:


### PR DESCRIPTION
The hardcoded paths did not work on Ubuntu 17.10. Besides,
there are a number of other directories in the path to consider
not just these, so there are other ways the old method to fail.

The new behavior tries to be smarter by installing deps directly
into the dist folder in the first place, removing the need to copy
the files later.