### PR TITLE
Fix username/password auth (no private key). Fixes #3

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,10 @@ def lambda_handler(event, context):
     ssh_password = os.environ.get('SSH_PASSWORD')
     key_filename = os.environ.get('SSH_KEY_FILENAME', 'key.pem')
 
-    pkey = paramiko.RSAKey.from_private_key(StringIO(PRIVATE_KEY))
+    pkey = None
+
+    if PRIVATE_KEY:
+        pkey = paramiko.RSAKey.from_private_key(StringIO(PRIVATE_KEY))
 
     if not os.path.isfile(key_filename):
         key_filename = None


### PR DESCRIPTION
When authenticating with username/password and no private
key, the code would fail, because the private key was
attempted to be used anyway. Error was:

    not a valid RSA private key file: SSHException Traceback (most recent call last): File "/var/task/main.py", line 18, in lambda_handler pkey = paramiko.RSAKey.from_private_key(StringIO(PRIVATE_KEY))

The fix is to only access the PRIVATE_KEY if it's actually set.

Manually tested.